### PR TITLE
Rewrite for React 15.5 and ES6 modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ lib/index.js
 # Bundles created by webpack
 **/public/*.js
 **/public/*.map
+.idea

--- a/lib/index.jsx
+++ b/lib/index.jsx
@@ -1,10 +1,9 @@
-'use strict';
-const React = require('react');
-const ReactDOM = require('react-dom');
-const PropTypes = React.PropTypes;
+import React from 'react';
+import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
 
-const DrawableCanvas = React.createClass({
-  propTypes: {
+class DrawableCanvas extends React.Component {
+  static propTypes = {
     brushColor: PropTypes.string,
     lineWidth: PropTypes.number,
     canvasStyle: PropTypes.shape({
@@ -12,28 +11,18 @@ const DrawableCanvas = React.createClass({
       cursor: PropTypes.string
     }),
     clear: PropTypes.bool
-  },
-  getDefaultProps() {
+  };
+
+  static getDefaultStyle() {
     return {
-      brushColor: '#000000',
-      lineWidth: 4,
-      canvasStyle: {
-        backgroundColor: '#FFFFFF',
-        cursor: 'pointer'
-      },
-      clear: false
-    };
-  },
-  getInitialState(){
-    return {
-      canvas: null,
-      context: null,
-      drawing: false,
-      lastX: 0,
-      lastY: 0,
-      history: []
-    };
-  },
+      backgroundColor: '#FFFFFF',
+      cursor: 'pointer'
+    }
+  };
+  static isMobile(){
+    return ( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) );
+  }
+
   componentDidMount(){
     let canvas = ReactDOM.findDOMNode(this);
 
@@ -48,16 +37,17 @@ const DrawableCanvas = React.createClass({
       canvas: canvas,
       context: ctx
     });
-  },
-  componentWillReceiveProps: function(nextProps) {
+  }
+  componentWillReceiveProps(nextProps) {
     if(nextProps.clear){
       this.resetCanvas();
     }
-  },
+  }
+
   handleOnMouseDown(e){
     let rect = this.state.canvas.getBoundingClientRect();
     this.state.context.beginPath();
-    if(this.isMobile()){
+    if(DrawableCanvas.isMobile()){
       this.setState({
         lastX: e.targetTouches[0].pageX - rect.left,
         lastY: e.targetTouches[0].pageY - rect.top
@@ -73,7 +63,8 @@ const DrawableCanvas = React.createClass({
     this.setState({
       drawing: true
     });
-  },
+  }
+
   handleOnMouseMove(e){
 
     if(this.state.drawing){
@@ -82,7 +73,7 @@ const DrawableCanvas = React.createClass({
       let lastY = this.state.lastY;
       let currentX;
       let currentY;
-      if(this.isMobile()){
+      if(DrawableCanvas.isMobile()){
         currentX =  e.targetTouches[0].pageX - rect.left;
         currentY = e.targetTouches[0].pageY - rect.top;
       }
@@ -98,55 +89,48 @@ const DrawableCanvas = React.createClass({
         lastY: currentY
       });
     }
-  },
-  handleonMouseUp(){
+  }
+
+  handleonMouseUp() {
     this.setState({
       drawing: false
     });
-  },
-  draw(lX, lY, cX, cY){
+  }
+
+  draw(lX, lY, cX, cY) {
     this.state.context.strokeStyle = this.props.brushColor;
     this.state.context.lineWidth = this.props.lineWidth;
     this.state.context.moveTo(lX,lY);
     this.state.context.lineTo(cX,cY);
     this.state.context.stroke();
-  },
+  }
+
   resetCanvas(){
     let width = this.state.context.canvas.width;
     let height = this.state.context.canvas.height;
     this.state.context.clearRect(0, 0, width, height);
-  },
-  getDefaultStyle(){
-    return {
-      backgroundColor: '#FFFFFF',
-      cursor: 'pointer'
-    };
-  },
+  }
+
   canvasStyle(){
-    let defaults =  this.getDefaultStyle();
+    let defaults =  DrawableCanvas.getDefaultStyle();
     let custom = this.props.canvasStyle;
     return Object.assign({}, defaults, custom);
-  },
-  isMobile(){
-    if( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
-      return true;
-    }
-    return false;
-  },
+  }
+
   render() {
     return (
       <canvas style = {this.canvasStyle()}
-        onMouseDown = {this.handleOnMouseDown}
-        onTouchStart = {this.handleOnMouseDown}
-        onMouseMove = {this.handleOnMouseMove}
-        onTouchMove = {this.handleOnMouseMove}
-        onMouseUp = {this.handleonMouseUp}
-        onTouchEnd = {this.handleonMouseUp}
+              onMouseDown = {this.handleOnMouseDown.bind(this)}
+              onTouchStart = {this.handleOnMouseDown.bind(this)}
+              onMouseMove = {this.handleOnMouseMove.bind(this)}
+              onTouchMove = {this.handleOnMouseMove.bind(this)}
+              onMouseUp = {this.handleonMouseUp.bind(this)}
+              onTouchEnd = {this.handleonMouseUp.bind(this)}
       >
       </canvas>
     );
   }
 
-});
+}
 
-module.exports = DrawableCanvas;
+export default DrawableCanvas;

--- a/lib/index.jsx
+++ b/lib/index.jsx
@@ -122,12 +122,12 @@ class DrawableCanvas extends React.Component {
   render() {
     return (
       <canvas style = {this.canvasStyle()}
-              onMouseDown = {this.handleOnMouseDown.bind(this)}
-              onTouchStart = {this.handleOnMouseDown.bind(this)}
-              onMouseMove = {this.handleOnMouseMove.bind(this)}
-              onTouchMove = {this.handleOnMouseMove.bind(this)}
-              onMouseUp = {this.handleonMouseUp.bind(this)}
-              onTouchEnd = {this.handleonMouseUp.bind(this)}
+        onMouseDown = {this.handleOnMouseDown.bind(this)}
+        onTouchStart = {this.handleOnMouseDown.bind(this)}
+        onMouseMove = {this.handleOnMouseMove.bind(this)}
+        onTouchMove = {this.handleOnMouseMove.bind(this)}
+        onMouseUp = {this.handleonMouseUp.bind(this)}
+        onTouchEnd = {this.handleonMouseUp.bind(this)}
       >
       </canvas>
     );

--- a/lib/index.jsx
+++ b/lib/index.jsx
@@ -20,7 +20,9 @@ class DrawableCanvas extends React.Component {
     }
   };
   static isMobile(){
-    return ( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) );
+    return (
+      /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)
+    );
   }
 
   componentDidMount(){
@@ -112,7 +114,7 @@ class DrawableCanvas extends React.Component {
   }
 
   canvasStyle(){
-    let defaults =  DrawableCanvas.getDefaultStyle();
+    let defaults = DrawableCanvas.getDefaultStyle();
     let custom = this.props.canvasStyle;
     return Object.assign({}, defaults, custom);
   }

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
     "babel-preset-es2015": "6.22.0",
     "babel-preset-react": "6.22.0",
     "uglify-js": "2.7.5"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-drawable-canvas",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "A React.js component for drawable canvas.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Hi, I've rewritten pieces of this for my own use. Since React 15.5 some parts like PropTypes and createClass are not supported anymore. PropTypes is now in its own package and createClass (while in its own package as well) is better written as class ** extends React.Component.

I've also moved some methods to be static on this class. Let me know if you want to merge this.

